### PR TITLE
Remove klippy from dstats.qmd

### DIFF
--- a/docs/tutorials/dstats/dstats.html
+++ b/docs/tutorials/dstats/dstats.html
@@ -139,10 +139,6 @@ gtag('config', 'G-VSGK4KYDQZ', { 'anonymize_ip': true});
         header.insertBefore(newContainer, navbar);
     });
 </script>
-<script src="../../site_libs/clipboard-1.7.1/clipboard.min.js"></script>
-<link href="../../site_libs/primer-tooltips-1.4.0/build.css" rel="stylesheet">
-<link href="../../site_libs/klippy-0.0.0.9500/css/klippy.min.css" rel="stylesheet">
-<script src="../../site_libs/klippy-0.0.0.9500/js/klippy.min.js"></script>
 <link href="../../site_libs/tabwid-1.1.3/tabwid.css" rel="stylesheet">
 <script src="../../site_libs/tabwid-1.1.3/tabwid.js"></script>
 
@@ -347,10 +343,7 @@ To be able to follow this tutorial, we suggest you check out and familiarize you
 <span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a><span class="fu">install.packages</span>(<span class="st">"ggpubr"</span>)</span>
 <span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a><span class="fu">install.packages</span>(<span class="st">"flextable"</span>)</span>
 <span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a><span class="fu">install.packages</span>(<span class="st">"psych"</span>)</span>
-<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a><span class="fu">install.packages</span>(<span class="st">"Rmisc"</span>)</span>
-<span id="cb1-11"><a href="#cb1-11" aria-hidden="true" tabindex="-1"></a><span class="co"># install klippy for copy-to-clipboard button in code chunks</span></span>
-<span id="cb1-12"><a href="#cb1-12" aria-hidden="true" tabindex="-1"></a><span class="fu">install.packages</span>(<span class="st">"remotes"</span>)</span>
-<span id="cb1-13"><a href="#cb1-13" aria-hidden="true" tabindex="-1"></a>remotes<span class="sc">::</span><span class="fu">install_github</span>(<span class="st">"rlesur/klippy"</span>)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a><span class="fu">install.packages</span>(<span class="st">"Rmisc"</span>)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 </div>
 <p>Now that we have installed the packages, we activate them as shown below.</p>
 <div class="cell">
@@ -366,15 +359,7 @@ To be able to follow this tutorial, we suggest you check out and familiarize you
 <span id="cb2-10"><a href="#cb2-10" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(flextable)</span>
 <span id="cb2-11"><a href="#cb2-11" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(ggpubr)</span>
 <span id="cb2-12"><a href="#cb2-12" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(psych)</span>
-<span id="cb2-13"><a href="#cb2-13" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(Rmisc)</span>
-<span id="cb2-14"><a href="#cb2-14" aria-hidden="true" tabindex="-1"></a><span class="co"># activate klippy for copy-to-clipboard button</span></span>
-<span id="cb2-15"><a href="#cb2-15" aria-hidden="true" tabindex="-1"></a>klippy<span class="sc">::</span><span class="fu">klippy</span>()</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
-<div class="cell-output-display">
-<script>
-  addClassKlippyTo("pre.r, pre.markdown");
-  addKlippy('left', 'top', 'auto', '1', 'Copy code', 'Copied!');
-</script>
-</div>
+<span id="cb2-13"><a href="#cb2-13" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(Rmisc)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 </div>
 <p>Once you have installed R and RStudio and initiated the session by executing the code shown above, you are good to go.</p>
 </section>

--- a/tutorials/dstats/dstats.qmd
+++ b/tutorials/dstats/dstats.qmd
@@ -53,9 +53,6 @@ install.packages("ggpubr")
 install.packages("flextable")
 install.packages("psych")
 install.packages("Rmisc")
-# install klippy for copy-to-clipboard button in code chunks
-install.packages("remotes")
-remotes::install_github("rlesur/klippy")
 ```
 
 Now that we have installed the packages, we activate them as shown below.
@@ -74,8 +71,6 @@ library(flextable)
 library(ggpubr)
 library(psych)
 library(Rmisc)
-# activate klippy for copy-to-clipboard button
-klippy::klippy()
 ```
 
 


### PR DESCRIPTION
Removed klippy from dstats.qmd as part of dependencies checking (no unused packaged)