### PR TITLE
Fix intro to leaflet tutorial

### DIFF
--- a/docs/tutorials/leaflet/leaflet.html
+++ b/docs/tutorials/leaflet/leaflet.html
@@ -261,14 +261,37 @@ gtag('config', 'G-VSGK4KYDQZ', { 'anonymize_ip': true});
 <p><img src="../../images/uq1.jpg" class="img-fluid" style="width:100.0%"></p>
 <section id="introduction" class="level1 unnumbered">
 <h1 class="unnumbered">Introduction</h1>
-<p>This document represents an empty R Quarto file (or qmd file) for a LADAL tutorial. The R Quarto document for this tutorial can be downloaded <a href="https://slcladal.github.io/content/base.Rmd">here</a>.</p>
-<p>You will also have to download the bibliography file from https://slcladal.github.io/content/references.bib for the tutorial to be knitted correctly. Although the knitted (or rendered) html file will look different from the LADAL design (because we have modified the theme for the LADAL page), it will be just like a proper LADAL tutorial once we have knitted the Rmd file on our machines and integrated your tutorial into the LADAL website.</p>
-<p><br></p>
+<p>This tutorial will show you how to create a typological map using R.</p>
 <div class="warning">
 <span>
 <p style="margin-top:1em; text-align:center">
-The entire R Notebook for the tutorial can be downloaded <a href="../../tutorials/leaflet/leaflet.html">here</a>. If you want to render the R Notebook on your machine, i.e.&nbsp;knitting the document to html or a pdf, you need to make sure that you have R and RStudio installed and you also need to download the <a href="../../assets/bibliography.bib"><strong>bibliography file</strong></a> and store it in the same folder where you store the Rmd or the Rproj file.
+To be able to follow this tutorial, we suggest you check out and familiarize yourself with the content of the following <strong>R Basics</strong> and <strong>Data Visualization</strong> tutorials:<br>
 </p>
+<p style="margin-top:1em; text-align:left">
+</p><ul>
+<li>
+<a href="../../tutorials/intror/intror.html">Getting started with R</a>
+</li>
+<li>
+<a href="../../tutorials/load/load.html">Loading, saving, and generating data in R</a>
+</li>
+<li>
+<a href="../../tutorials/string/string.html">String Processing in R</a>
+</li>
+<li>
+<a href="../../tutorials/regex/regex.html">Regular Expressions in R</a>
+</li>
+<li>
+<a href="../../tutorials/table/table.html">Handling Tables in R</a>
+</li>
+<li>
+<a href="../../tutorials/introviz/introviz.html">Introduction to Data Viz</a>
+</li>
+<li>
+<a href="../../tutorials/dviz/dviz.html">Data Visualization with R</a>
+</li>
+</ul>
+<p></p>
 <p></p>
 </span></div>
 <p><br></p>

--- a/tutorials/leaflet/leaflet.qmd
+++ b/tutorials/leaflet/leaflet.qmd
@@ -8,21 +8,26 @@ author: "Ludovic De Cuypere"
 
 # Introduction {#introduction .unnumbered}
 
-This document represents an empty R Quarto file (or qmd file) for a LADAL tutorial. The R Quarto document for this tutorial can be downloaded [here](https://slcladal.github.io/content/base.Rmd).
-
-You will also have to download the bibliography file from https://slcladal.github.io/content/references.bib for the tutorial to be knitted correctly. Although the knitted (or rendered) html file will look different from the LADAL design (because we have modified the theme for the LADAL page), it will be just like a proper LADAL tutorial once we have knitted the Rmd file on our machines and integrated your tutorial into the LADAL website.
-
-
-<br>
+This tutorial will show you how to create a typological map using R.
 
 <div class="warning">
 <span>
 <p style='margin-top:1em; text-align:center'>
-The entire R Notebook for the tutorial can be downloaded [here](/tutorials/leaflet/leaflet.qmd).  If you want to render the R Notebook on your machine, i.e. knitting the document to html or a pdf, you need to make sure that you have R and RStudio installed and you also need to download the [**bibliography file**](/assets/bibliography.bib) and store it in the same folder where you store the Rmd or the Rproj file.
+To be able to follow this tutorial, we suggest you check out and familiarize yourself with the content of the following **R Basics** and **Data Visualization** tutorials:<br>
+</p>
+<p style='margin-top:1em; text-align:left'>
+<ul>
+  <li>[Getting started with R](/tutorials/intror/intror.html) </li>
+  <li>[Loading, saving, and generating data in R](/tutorials/load/load.html) </li>
+  <li>[String Processing in R](/tutorials/string/string.html) </li>
+  <li>[Regular Expressions in R](/tutorials/regex/regex.html) </li>
+  <li>[Handling Tables in R](/tutorials/table/table.html) </li>
+  <li>[Introduction to Data Viz](/tutorials/introviz/introviz.html) </li>
+  <li>[Data Visualization with R](/tutorials/dviz/dviz.html) </li>
+</ul>
 </p>
 </span>
 </div>
-
 <br>
 
 **Preparation and session set up**


### PR DESCRIPTION
The previous introduction seemed to be from a tutorial template/instructions. I have just replaced it with a single sentence for now, but maybe it could be reworked so that 'typological data' section becomes the new introduction? 