### PR TITLE
Update repro intro

### DIFF
--- a/docs/tutorials/repro/repro.html
+++ b/docs/tutorials/repro/repro.html
@@ -8,7 +8,7 @@
 
 <meta name="author" content="Martin Schweinberger">
 
-<title>Reproducible Research – Language Technology and Data Analysis Laboratory (LADAL)</title>
+<title>Concepts in Reproducible Research – Language Technology and Data Analysis Laboratory (LADAL)</title>
 <style>
 code{white-space: pre-wrap;}
 span.smallcaps{font-variant: small-caps;}
@@ -231,7 +231,7 @@ gtag('config', 'G-VSGK4KYDQZ', { 'anonymize_ip': true});
 
 <header id="title-block-header" class="quarto-title-block default">
 <div class="quarto-title">
-<div class="quarto-title-block"><div><h1 class="title">Reproducible Research</h1><button type="button" class="btn code-tools-button" id="quarto-code-tools-source" data-quarto-source-url="https://github.com/SLCLADAL/ladal/blob/main/tutorials/repro/repro.qmd"><i class="bi"></i> Download This Notebook</button></div></div>
+<div class="quarto-title-block"><div><h1 class="title">Concepts in Reproducible Research</h1><button type="button" class="btn code-tools-button" id="quarto-code-tools-source" data-quarto-source-url="https://github.com/SLCLADAL/ladal/blob/main/tutorials/repro/repro.qmd"><i class="bi"></i> Download This Notebook</button></div></div>
 </div>
 
 
@@ -258,11 +258,10 @@ gtag('config', 'G-VSGK4KYDQZ', { 'anonymize_ip': true});
 <section id="introduction" class="level1 unnumbered">
 <h1 class="unnumbered">Introduction</h1>
 <p><img src="../../images/g_chili.jpg" class="img-fluid" style="float:right; padding:10px;width:15.0%"></p>
-<p>This tutorial introduces issues relating to reproducible research and shows how to make research and workflows more transparent and efficient.</p>
-<p>This tutorial is designed to provide essential guidance on transparency and reproducibility for individuals working with language data. While it is accessible to all users, it focuses particularly on beginners and intermediate users of R, aiming to enhance their data management skills and utilise RStudio to make their analyses more transparent and reproducible.</p>
+<p>This tutorial introduces issues relating to reproducible research and shows how to make research and workflows more transparent and efficient. It is designed to provide essential guidance on transparency and reproducibility for individuals working with language data.</p>
 <p><img src="../../images/reprocicle.png" class="img-fluid" style="float:right; padding:10px;width:40.0%"></p>
-<p>The objective of this tutorial is to demonstrate fundamental strategies for reproducible research and to exemplify selected methods that improve the reproducibility of analytic workflows. By following this tutorial, users will learn to implement best practices that ensure their workflows are transparent, and make their results reproducible, thereby increasing the reliability and credibility of their research.</p>
-<p>Furthermore, the tutorial will cover essential techniques such as version control with Git, using R Markdown for creating dynamic documents, strategies for organising and documenting your code effectively, developing interactive Jupyter notebooks, and creating eBooks that are accessible via any browser. These methods are crucial for creating analyses that others can easily understand, verify, and build upon. By adopting these practices, you contribute to a more open and collaborative scientific community.</p>
+<p>The objective of this tutorial is to discuss and differentiate key concepts in reproducible research and to outline simple strategies that improve the reproducibility of analytic workflows. By following this tutorial, users can begin to think about practices that ensure their workflows are transparent and their results reproducible, thereby increasing the reliability and credibility of their research.</p>
+<p>This tutorial will also briefly introduce essential techniques such as version control with Git and effective documentation strategies. These methods are crucial for creating analyses that others can easily understand, verify, and build upon. By adopting these practices, you contribute to a more open and collaborative scientific community. For some more practical tips on reproducible research practices using R and RStudio, see our <a href="../../tutorials/r_reproducibility/r_reproducibility.html">Reproducibility with R</a> tutorial.</p>
 </section>
 <section id="basic-concepts-in-reproducibility" class="level1 unnumbered">
 <h1 class="unnumbered">Basic Concepts in Reproducibility</h1>
@@ -367,10 +366,10 @@ gtag('config', 'G-VSGK4KYDQZ', { 'anonymize_ip': true});
 </section>
 <section id="citation-session-info" class="level1 unnumbered">
 <h1 class="unnumbered">Citation &amp; Session Info</h1>
-<p>Schweinberger, Martin. 2024. <em>Reproducible Research</em>. Brisbane: The University of Queensland. url: https://ladal.edu.au/tutorials/repro.html (Version 2025.08.01).</p>
+<p>Schweinberger, Martin. 2024. <em>Concepts in Reproducible Research</em>. Brisbane: The University of Queensland. url: https://ladal.edu.au/tutorials/repro.html (Version 2025.08.01).</p>
 <pre><code>@manual{schweinberger2025repro,
   author = {Schweinberger, Martin},
-  title = {Reproducible Research},
+  title = {Concepts in Reproducible Research},
   note = {tutorials/repro/repro.html},
   year = {2025},
   organization = {The University of Queensland, School of Languages and Cultures},

--- a/tutorials/repro/repro.qmd
+++ b/tutorials/repro/repro.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Reproducible Research"
+title: "Concepts in Reproducible Research"
 author: "Martin Schweinberger"
 ---
 
@@ -9,16 +9,14 @@ author: "Martin Schweinberger"
 
 ![](/images/g_chili.jpg){ width=15% style="float:right; padding:10px" }
 
-This tutorial introduces issues relating to reproducible research and shows how to make research and workflows more transparent and efficient. 
-
-This tutorial is designed to provide essential guidance on transparency and reproducibility for individuals working with language data. While it is accessible to all users, it focuses particularly on beginners and intermediate users of R, aiming to enhance their data management skills and utilise RStudio to make their analyses more transparent and reproducible.
+This tutorial introduces issues relating to reproducible research and shows how to make research and workflows more transparent and efficient. It is designed to provide essential guidance on transparency and reproducibility for individuals working with language data.
 
 ![](/images/reprocicle.png){ width=40% style="float:right; padding:10px" }
 
 
-The objective of this tutorial is to demonstrate fundamental strategies for reproducible research and to exemplify selected methods that improve the reproducibility of analytic workflows. By following this tutorial, users will learn to implement best practices that ensure their workflows are transparent, and make their results reproducible, thereby increasing the reliability and credibility of their research.
+The objective of this tutorial is to discuss and differentiate key concepts in reproducible research and to outline simple strategies that improve the reproducibility of analytic workflows. By following this tutorial, users can begin to think about practices that ensure their workflows are transparent and their results reproducible, thereby increasing the reliability and credibility of their research.
 
-Furthermore, the tutorial will cover essential techniques such as version control with Git, using R Markdown for creating dynamic documents, strategies for organising and documenting your code effectively, developing interactive Jupyter notebooks, and creating eBooks that are accessible via any browser. These methods are crucial for creating analyses that others can easily understand, verify, and build upon. By adopting these practices, you contribute to a more open and collaborative scientific community.  
+This tutorial will also briefly introduce essential techniques such as version control with Git and effective documentation strategies. These methods are crucial for creating analyses that others can easily understand, verify, and build upon. By adopting these practices, you contribute to a more open and collaborative scientific community. For some more practical tips on reproducible research practices using R and RStudio, see our [Reproducibility with R](/tutorials/r_reproducibility/r_reproducibility.html) tutorial. 
 
 # Basic Concepts in Reproducibility {-}
 
@@ -154,12 +152,12 @@ A DOI will also be given to any data set published in UQ eSpace, whether added m
 
 # Citation & Session Info {-}
 
-Schweinberger, Martin. 2024. *Reproducible Research*. Brisbane: The University of Queensland. url: https://ladal.edu.au/tutorials/repro.html (Version 2025.08.01).
+Schweinberger, Martin. 2024. *Concepts in Reproducible Research*. Brisbane: The University of Queensland. url: https://ladal.edu.au/tutorials/repro.html (Version 2025.08.01).
 
 ```
 @manual{schweinberger2025repro,
   author = {Schweinberger, Martin},
-  title = {Reproducible Research},
+  title = {Concepts in Reproducible Research},
   note = {tutorials/repro/repro.html},
   year = {2025},
   organization = {The University of Queensland, School of Languages and Cultures},


### PR DESCRIPTION
Edited repro tutorial introduction to match the contents of the new shortened tutorial (after R section moved to its own tutorial). Also changed title from Reproducible Research to Concepts in Reproducible Research to differentiate it a bit more from the new Reproducibility with R tutorial, but this can be changed back if necessary. 